### PR TITLE
add https url to correctly work with new build tools

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ allprojects {
         mavenLocal()
         jcenter()
         maven {
-            url "http://files.couchbase.com/maven2/"
+            url "https://files.couchbase.com/maven2/"
         }
     }
 }


### PR DESCRIPTION
New Build tools are not redirecting to non https urls
